### PR TITLE
Add RAG chunk quality control app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # ai_projects
-AI projects
+
+Collection of experimental AI utilities. Subprojects include:
+
+- **md_a2a** – Medical AI Assistant demonstration.
+- **rag_chunk_quality** – Scripts for high-quality document chunking and indexing for Retrieval-Augmented Generation systems.

--- a/rag_chunk_quality/README.md
+++ b/rag_chunk_quality/README.md
@@ -1,0 +1,18 @@
+# RAG Chunk Quality Control
+
+This app provides utilities for preprocessing documents for Retrieval-Augmented Generation (RAG) systems.
+It performs chunking with quality checks before indexing so that only meaningful content is stored in the
+vector database.
+
+## Features
+- Splits text files using `RecursiveCharacterTextSplitter` from LangChain.
+- Removes near-duplicate chunks based on embedding similarity.
+- Filters low-information chunks (short length or high punctuation).
+- Enforces minimum and maximum token lengths.
+- Saves embeddings to a FAISS index for later retrieval.
+
+## Quick Start
+```bash
+pip install -r requirements.txt
+python -m rag_chunk_quality.cli mydoc.txt --index index.faiss --chunks chunks.json
+```

--- a/rag_chunk_quality/chunk_quality.py
+++ b/rag_chunk_quality/chunk_quality.py
@@ -1,0 +1,107 @@
+"""Utilities for chunk quality control."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from sentence_transformers import SentenceTransformer
+from sklearn.metrics.pairwise import cosine_similarity
+
+
+@dataclass
+class ProcessedChunks:
+    """Container for chunks and their embeddings."""
+
+    chunks: List[str]
+    embeddings: np.ndarray
+
+
+class ChunkQualityProcessor:
+    """Process documents into high-quality chunks."""
+
+    def __init__(
+        self,
+        model_name: str = "all-MiniLM-L6-v2",
+        chunk_size: int = 1000,
+        chunk_overlap: int = 200,
+        min_tokens: int = 50,
+        max_tokens: int = 512,
+        duplicate_threshold: float = 0.9,
+    ) -> None:
+        self.splitter = RecursiveCharacterTextSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            length_function=len,
+            separators=["\n\n", "\n", ".", "?", "!", " "],
+        )
+        self.embedder = SentenceTransformer(model_name)
+        self.min_tokens = min_tokens
+        self.max_tokens = max_tokens
+        self.duplicate_threshold = duplicate_threshold
+
+    def split_text(self, text: str) -> List[str]:
+        """Split text into raw chunks."""
+        return self.splitter.split_text(text)
+
+    def embed(self, chunks: List[str]) -> np.ndarray:
+        """Compute embeddings for chunks."""
+        return self.embedder.encode(chunks)
+
+    def remove_duplicates(
+        self, chunks: List[str], embeddings: np.ndarray
+    ) -> Tuple[List[str], np.ndarray]:
+        """Drop near-duplicate chunks."""
+        unique_chunks: List[str] = []
+        unique_embeds: List[np.ndarray] = []
+        for idx, chunk in enumerate(chunks):
+            if not unique_embeds:
+                unique_chunks.append(chunk)
+                unique_embeds.append(embeddings[idx])
+                continue
+            sims = cosine_similarity([embeddings[idx]], np.array(unique_embeds))
+            if sims.max() < self.duplicate_threshold:
+                unique_chunks.append(chunk)
+                unique_embeds.append(embeddings[idx])
+        return unique_chunks, np.array(unique_embeds)
+
+    def filter_low_info(
+        self, chunks: List[str], embeddings: np.ndarray
+    ) -> Tuple[List[str], np.ndarray]:
+        """Remove low-information or size-extreme chunks."""
+        filtered_chunks: List[str] = []
+        filtered_embeds: List[np.ndarray] = []
+        for chunk, emb in zip(chunks, embeddings):
+            tokens = chunk.split()
+            if len(tokens) < self.min_tokens or len(tokens) > self.max_tokens:
+                continue
+            punctuation = sum(1 for c in chunk if c in ",.;:!?")
+            if punctuation / max(len(chunk), 1) > 0.5:
+                continue
+            filtered_chunks.append(chunk)
+            filtered_embeds.append(emb)
+        return filtered_chunks, np.array(filtered_embeds)
+
+    def process_text(self, text: str) -> ProcessedChunks:
+        """Full pipeline for a single text string."""
+        raw_chunks = self.split_text(text)
+        embeds = self.embed(raw_chunks)
+        chunks, embeds = self.remove_duplicates(raw_chunks, embeds)
+        chunks, embeds = self.filter_low_info(chunks, embeds)
+        return ProcessedChunks(chunks=chunks, embeddings=embeds)
+
+    def process_files(self, paths: List[Path]) -> ProcessedChunks:
+        """Process multiple files and concatenate results."""
+        all_chunks: List[str] = []
+        all_embeds: List[np.ndarray] = []
+        for path in paths:
+            text = path.read_text(encoding="utf-8")
+            result = self.process_text(text)
+            all_chunks.extend(result.chunks)
+            all_embeds.append(result.embeddings)
+        if not all_embeds:
+            return ProcessedChunks([], np.empty((0, 384)))
+        return ProcessedChunks(chunks=all_chunks, embeddings=np.vstack(all_embeds))

--- a/rag_chunk_quality/cli.py
+++ b/rag_chunk_quality/cli.py
@@ -1,0 +1,47 @@
+"""Command line interface for chunk quality processing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import faiss
+import numpy as np
+
+from .chunk_quality import ChunkQualityProcessor
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Chunk quality control and indexing")
+    parser.add_argument("input", nargs="+", help="Text files to process")
+    parser.add_argument("--index", default="index.faiss", help="Output FAISS index")
+    parser.add_argument(
+        "--chunks",
+        default="chunks.json",
+        help="Path to save processed chunks as JSON",
+    )
+    args = parser.parse_args()
+
+    paths = [Path(p) for p in args.input]
+    processor = ChunkQualityProcessor()
+    result = processor.process_files(paths)
+
+    if result.embeddings.size == 0:
+        print("No chunks created")
+        return
+
+    dimension = result.embeddings.shape[1]
+    index = faiss.IndexFlatL2(dimension)
+    index.add(result.embeddings.astype(np.float32))
+    faiss.write_index(index, args.index)
+
+    with open(args.chunks, "w", encoding="utf-8") as f:
+        json.dump(result.chunks, f, ensure_ascii=False, indent=2)
+
+    print(f"Saved {len(result.chunks)} chunks")
+    print(f"Index written to {args.index}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rag_chunk_quality/requirements.txt
+++ b/rag_chunk_quality/requirements.txt
@@ -1,0 +1,4 @@
+langchain==0.1.20
+faiss-cpu==1.7.4
+sentence-transformers==2.7.0
+scikit-learn==1.4.2


### PR DESCRIPTION
## Summary
- document subprojects in repo README
- add `rag_chunk_quality` module with utilities for chunk quality control
- include CLI to build a FAISS index with cleaned chunks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic._internal')*

------
https://chatgpt.com/codex/tasks/task_e_6841a4685c8883328b916f90c20da60e